### PR TITLE
Prevent ALL access to $SYS from outside localhost.

### DIFF
--- a/rel/files/acl.config
+++ b/rel/files/acl.config
@@ -20,7 +20,7 @@
 
 {allow, {ipaddr, "127.0.0.1"}, pubsub, ["$SYS/#", "#"]}.
 
-{deny, all, subscribe, [{eq, "$SYS/#"}, {eq, "#"}]}.
+{deny, all, subscribe, ["$SYS/#", {eq, "#"}]}.
 
 {allow, all}.
 


### PR DESCRIPTION
The structure of $SYS is pretty well known or can be guessed and can contain non-public information and therefore should be protected.