### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ emqttd is aimed to provide a solid, enterprise grade, extensible open-source MQT
 * [emqttd_dashboard](https://github.com/emqtt/emqttd_dashboard) - Web Dashboard
 * [emqttd_plugin_mysql](https://github.com/emqtt/emqttd_plugin_mysql) - Authentication with MySQL
 * [emqttd_plugin_pgsql](https://github.com/emqtt/emqttd_plugin_pgsql) - Authentication with PostgreSQL
-* [emqttd_plugin_kafka](https://github.com/emqtt/emqttd_plugin_kafka) - Publish MQTT Messages to Kafka
-* [emqttd_plugin_redis](https://github.com/emqtt/emqttd_plugin_redis) - Redis Plugin
+* [emqttd_plugin_kafka](https://github.com/emqtt/emqtt_kafka) - Publish MQTT Messages to Kafka
+* [emqttd_plugin_redis](https://github.com/emqtt/emqtt_redis) - Redis Plugin
 * [emqttd_stomp](https://github.com/emqtt/emqttd_stomp) - Stomp Protocol Plugin
 * [emqttd_sockjs](https://github.com/emqtt/emqttd_sockjs) - SockJS(Stomp) Plugin
 * [emqttd_recon](https://github.com/emqtt/emqttd_recon) - Recon Plugin


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/emqtt/emqttd_plugin_kafka | https://github.com/emqtt/emqtt_kafka 
https://github.com/emqtt/emqttd_plugin_redis | https://github.com/emqtt/emqtt_redis 
