### PR TITLE
Add runtime deps on gproc and esockd

### DIFF
--- a/src/emqttd.app.src
+++ b/src/emqttd.app.src
@@ -6,7 +6,9 @@
   {modules, []},
   {registered, []},
   {applications, [kernel,
-                  stdlib]},
+                  stdlib,
+                  gproc,
+                  esockd]},
   {mod, {emqttd_app, []}},
   {env, []}
  ]}.


### PR DESCRIPTION
Adds missing runtime dependencies on gproc and esockd to `src/emqttd.app.src`