### PR TITLE
rename modules with pattern appname_modulename

### DIFF
--- a/rel/files/emqttd.config.development
+++ b/rel/files/emqttd.config.development
@@ -18,7 +18,7 @@
     {handlers, [
         {lager_console_backend, info},
         %%NOTICE: Level >= error
-        %%{lager_emqtt_backend, error},
+        %%{emqttd_lager_backend, error},
         {lager_file_backend, [
             {formatter_config, [time, " ", pid, " [",severity,"] ", message, "\n"]},
             {file, "log/emqttd_info.log"},

--- a/rel/files/emqttd.config.production
+++ b/rel/files/emqttd.config.production
@@ -18,7 +18,7 @@
     {handlers, [
         %%{lager_console_backend, info},
         %%NOTICE: Level >= error
-        %%{lager_emqtt_backend, error},
+        %%{emqttd_lager_backend, error},
         {lager_file_backend, [
             {formatter_config, [time, " ", pid, " [",severity,"] ", message, "\n"]},
             {file, "log/emqttd_error.log"},

--- a/rel/files/test.config
+++ b/rel/files/test.config
@@ -18,7 +18,7 @@
     {handlers, [
         {lager_console_backend, info},
         %%NOTICE: Level >= error
-        %%{lager_emqtt_backend, error},
+        %%{emqttd_lager_backend, error},
         {lager_file_backend, [
             {formatter_config, [time, " ", pid, " [",severity,"] ", message, "\n"]},
             {file, "log/emqttd_info.log"},

--- a/src/emqttd_bridge.erl
+++ b/src/emqttd_bridge.erl
@@ -16,7 +16,7 @@
 
 -module(emqttd_bridge).
 
--behaviour(gen_server2).
+-behaviour(emqttd_gen_server2).
 
 -include("emqttd.hrl").
 
@@ -57,7 +57,7 @@
 %% @doc Start a bridge
 -spec start_link(atom(), binary(), [option()]) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Node, Topic, Options) ->
-    gen_server2:start_link(?MODULE, [Node, Topic, Options], []).
+    emqttd_gen_server2:start_link(?MODULE, [Node, Topic, Options], []).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/src/emqttd_cm.erl
+++ b/src/emqttd_cm.erl
@@ -17,7 +17,7 @@
 %% @doc MQTT Client Manager
 -module(emqttd_cm).
 
--behaviour(gen_server2).
+-behaviour(emqttd_gen_server2).
 
 -include("emqttd.hrl").
 
@@ -49,7 +49,7 @@
         Id   :: pos_integer(),
         StatsFun :: fun().
 start_link(Pool, Id, StatsFun) ->
-    gen_server2:start_link(?MODULE, [Pool, Id, StatsFun], []).
+    emqttd_gen_server2:start_link(?MODULE, [Pool, Id, StatsFun], []).
 
 %% @doc Lookup Client by ClientId
 -spec lookup(ClientId :: binary()) -> mqtt_client() | undefined.
@@ -71,13 +71,13 @@ lookup_proc(ClientId) when is_binary(ClientId) ->
 -spec register(Client :: mqtt_client()) -> ok.
 register(Client = #mqtt_client{client_id = ClientId}) ->
     CmPid = gproc_pool:pick_worker(?POOL, ClientId),
-    gen_server2:cast(CmPid, {register, Client}).
+    emqttd_gen_server2:cast(CmPid, {register, Client}).
 
 %% @doc Unregister clientId with pid.
 -spec unregister(ClientId :: binary()) -> ok.
 unregister(ClientId) when is_binary(ClientId) ->
     CmPid = gproc_pool:pick_worker(?POOL, ClientId),
-    gen_server2:cast(CmPid, {unregister, ClientId, self()}).
+    emqttd_gen_server2:cast(CmPid, {unregister, ClientId, self()}).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/src/emqttd_lager_backend.erl
+++ b/src/emqttd_lager_backend.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(lager_emqtt_backend).
+-module(emqttd_lager_backend).
 
 -behaviour(gen_event).
 

--- a/src/emqttd_priority_queue.erl
+++ b/src/emqttd_priority_queue.erl
@@ -37,7 +37,7 @@
 %% calls into the same function knowing that ordinary queues represent
 %% a base case.
 
--module(priority_queue).
+-module(emqttd_priority_queue).
 
 -export([new/0, is_queue/1, is_empty/1, len/1, plen/2, to_list/1, from_list/1,
          in/2, in/3, out/1, out/2, out_p/1, join/2, filter/2, fold/3, highest/1]).

--- a/src/emqttd_pubsub.erl
+++ b/src/emqttd_pubsub.erl
@@ -16,7 +16,7 @@
 
 -module(emqttd_pubsub).
 
--behaviour(gen_server2).
+-behaviour(emqttd_gen_server2).
 
 -include("emqttd.hrl").
 
@@ -113,7 +113,7 @@ cache_env(Key) ->
     StatsFun :: fun((atom()) -> any()),
     Opts     :: list(tuple()).
 start_link(Pool, Id, StatsFun, Opts) ->
-    gen_server2:start_link({local, ?PROC_NAME(?MODULE, Id)},
+    emqttd_gen_server2:start_link({local, ?PROC_NAME(?MODULE, Id)},
                            ?MODULE, [Pool, Id, StatsFun, Opts], []).
 
 %% @doc Create Topic or Subscription.
@@ -190,10 +190,10 @@ unsubscribe(ClientId, Topics = [Topic|_]) when is_binary(Topic) ->
     cast({unsubscribe, {ClientId, self()}, Topics}).
 
 call(Request) ->
-    gen_server2:call(pick(self()), Request, infinity).
+    emqttd_gen_server2:call(pick(self()), Request, infinity).
 
 cast(Msg) ->
-    gen_server2:cast(pick(self()), Msg).
+    emqttd_gen_server2:cast(pick(self()), Msg).
 
 pick(Self) -> gproc_pool:pick_worker(pubsub, Self).
 

--- a/src/emqttd_router.erl
+++ b/src/emqttd_router.erl
@@ -19,7 +19,7 @@
 %% @end
 -module(emqttd_router).
 
--behaviour(gen_server2).
+-behaviour(emqttd_gen_server2).
 
 -include("emqttd.hrl").
 
@@ -52,7 +52,7 @@
 %% @doc Start a router.
 -spec start_link(atom(), pos_integer(), fun((atom()) -> ok), list()) -> {ok, pid()} | {error, any()}.
 start_link(Pool, Id, StatsFun, Env) ->
-    gen_server2:start_link({local, ?PROC_NAME(?MODULE, Id)},
+    emqttd_gen_server2:start_link({local, ?PROC_NAME(?MODULE, Id)},
                            ?MODULE, [Pool, Id, StatsFun, Env], []).
 
 %% @doc Route Message on this node.
@@ -147,15 +147,15 @@ pick(Topic) ->
 
 %% @doc For unit test.
 stop(Id) when is_integer(Id) ->
-    gen_server2:call(?PROC_NAME(?MODULE, Id), stop);
+    emqttd_gen_server2:call(?PROC_NAME(?MODULE, Id), stop);
 stop(Pid) when is_pid(Pid) ->
-    gen_server2:call(Pid, stop).
+    emqttd_gen_server2:call(Pid, stop).
 
 call(Router, Request) ->
-    gen_server2:call(Router, Request, infinity).
+    emqttd_gen_server2:call(Router, Request, infinity).
 
 cast(Router, Msg) ->
-    gen_server2:cast(Router, Msg).
+    emqttd_gen_server2:cast(Router, Msg).
 
 init([Pool, Id, StatsFun, Opts]) ->
 

--- a/src/emqttd_session.erl
+++ b/src/emqttd_session.erl
@@ -45,7 +45,7 @@
 
 -include("emqttd_internal.hrl").
 
--behaviour(gen_server2).
+-behaviour(emqttd_gen_server2).
 
 -import(proplists, [get_value/2, get_value/3]).
 
@@ -138,26 +138,26 @@
 %% @doc Start a session.
 -spec start_link(boolean(), mqtt_client_id(), pid()) -> {ok, pid()} | {error, any()}.
 start_link(CleanSess, ClientId, ClientPid) ->
-    gen_server2:start_link(?MODULE, [CleanSess, ClientId, ClientPid], []).
+    emqttd_gen_server2:start_link(?MODULE, [CleanSess, ClientId, ClientPid], []).
 
 %% @doc Resume a session.
 -spec resume(pid(), mqtt_client_id(), pid()) -> ok.
 resume(SessPid, ClientId, ClientPid) ->
-    gen_server2:cast(SessPid, {resume, ClientId, ClientPid}).
+    emqttd_gen_server2:cast(SessPid, {resume, ClientId, ClientPid}).
 
 %% @doc Session Info.
 info(SessPid) ->
-    gen_server2:call(SessPid, info).
+    emqttd_gen_server2:call(SessPid, info).
 
 %% @doc Destroy a session.
 -spec destroy(pid(), mqtt_client_id()) -> ok.
 destroy(SessPid, ClientId) ->
-    gen_server2:cast(SessPid, {destroy, ClientId}).
+    emqttd_gen_server2:cast(SessPid, {destroy, ClientId}).
 
 %% @doc Subscribe Topics
 -spec subscribe(pid(), [{binary(), mqtt_qos()}]) -> ok.
 subscribe(SessPid, TopicTable) ->
-    gen_server2:cast(SessPid, {subscribe, TopicTable, fun(_) -> ok end}).
+    emqttd_gen_server2:cast(SessPid, {subscribe, TopicTable, fun(_) -> ok end}).
 
 -spec subscribe(pid(), mqtt_packet_id(), [{binary(), mqtt_qos()}]) -> ok.
 subscribe(SessPid, PacketId, TopicTable) ->
@@ -165,7 +165,7 @@ subscribe(SessPid, PacketId, TopicTable) ->
     AckFun = fun(GrantedQos) ->
                From ! {suback, PacketId, GrantedQos}
              end,
-    gen_server2:cast(SessPid, {subscribe, TopicTable, AckFun}).
+    emqttd_gen_server2:cast(SessPid, {subscribe, TopicTable, AckFun}).
 
 %% @doc Publish message
 -spec publish(pid(), mqtt_message()) -> ok | {error, any()}.
@@ -179,29 +179,29 @@ publish(_SessPid, Msg = #mqtt_message{qos = ?QOS_1}) ->
 
 publish(SessPid, Msg = #mqtt_message{qos = ?QOS_2}) ->
     %% publish qos2 by session 
-    gen_server2:call(SessPid, {publish, Msg}, ?PUBSUB_TIMEOUT).
+    emqttd_gen_server2:call(SessPid, {publish, Msg}, ?PUBSUB_TIMEOUT).
 
 %% @doc PubAck message
 -spec puback(pid(), mqtt_packet_id()) -> ok.
 puback(SessPid, PktId) ->
-    gen_server2:cast(SessPid, {puback, PktId}).
+    emqttd_gen_server2:cast(SessPid, {puback, PktId}).
 
 -spec pubrec(pid(), mqtt_packet_id()) -> ok.
 pubrec(SessPid, PktId) ->
-    gen_server2:cast(SessPid, {pubrec, PktId}).
+    emqttd_gen_server2:cast(SessPid, {pubrec, PktId}).
 
 -spec pubrel(pid(), mqtt_packet_id()) -> ok.
 pubrel(SessPid, PktId) ->
-    gen_server2:cast(SessPid, {pubrel, PktId}).
+    emqttd_gen_server2:cast(SessPid, {pubrel, PktId}).
 
 -spec pubcomp(pid(), mqtt_packet_id()) -> ok.
 pubcomp(SessPid, PktId) ->
-    gen_server2:cast(SessPid, {pubcomp, PktId}).
+    emqttd_gen_server2:cast(SessPid, {pubcomp, PktId}).
 
 %% @doc Unsubscribe Topics
 -spec unsubscribe(pid(), [binary()]) -> ok.
 unsubscribe(SessPid, Topics) ->
-    gen_server2:cast(SessPid, {unsubscribe, Topics}).
+    emqttd_gen_server2:cast(SessPid, {unsubscribe, Topics}).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/src/emqttd_sm.erl
+++ b/src/emqttd_sm.erl
@@ -17,7 +17,7 @@
 %% @doc Session Manager
 -module(emqttd_sm).
 
--behaviour(gen_server2).
+-behaviour(emqttd_gen_server2).
 
 -include("emqttd.hrl").
 
@@ -74,7 +74,7 @@ mnesia(copy) ->
 %% @doc Start a session manager
 -spec start_link(atom(), pos_integer()) -> {ok, pid()} | ignore | {error, any()}.
 start_link(Pool, Id) ->
-    gen_server2:start_link({local, ?PROC_NAME(?MODULE, Id)}, ?MODULE, [Pool, Id], []).
+    emqttd_gen_server2:start_link({local, ?PROC_NAME(?MODULE, Id)}, ?MODULE, [Pool, Id], []).
 
 %% @doc Start a session
 -spec start_session(CleanSess :: boolean(), binary()) -> {ok, pid(), boolean()} | {error, any()}.
@@ -109,7 +109,7 @@ sesstab(true)  -> mqtt_transient_session;
 sesstab(false) -> mqtt_persistent_session.
 
 call(SM, Req) ->
-    gen_server2:call(SM, Req, ?TIMEOUT). %%infinity).
+    emqttd_gen_server2:call(SM, Req, ?TIMEOUT). %%infinity).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/test/emqttd_lib_SUITE.erl
+++ b/test/emqttd_lib_SUITE.erl
@@ -26,7 +26,7 @@
 	{nodelay,   true}
 ]).
 
--define(PQ, priority_queue).
+-define(PQ, emqttd_priority_queue).
 
 all() -> [{group, guid}, {group, opts},
           {group, ?PQ}, {group, time},


### PR DESCRIPTION
When I tried to add in my plugin rabbitmq-erlang-client and created release I got the next error:
`{'EXIT',{{badmatch,{error,"Module gen_server2 potentially included by two different applications: emqttd and rabbit_common."}},
`
 I found 3 modules which names didn't match with convention [http://www.erlang.se/doc/programming_rules.shtml#HDR30](url)

So I decided to change it. Please check it and approve this pool request. On my workstation all tests passed successfully. 
