### PR TITLE
enhance emqttd_client ratelimit handling

### DIFF
--- a/src/emqttd_client.erl
+++ b/src/emqttd_client.erl
@@ -26,7 +26,8 @@
 -include("emqttd_internal.hrl").
 
 %% API Function Exports
--export([start_link/2, session/1, info/1, kick/1]).
+-export([start_link/2, session/1, info/1, kick/1,
+         set_rate_limit/2, get_rate_limit/1]).
 
 %% SUB/UNSUB Asynchronously. Called by plugins.
 -export([subscribe/2, unsubscribe/2]).
@@ -58,6 +59,12 @@ info(CPid) ->
 
 kick(CPid) ->
     gen_server:call(CPid, kick).
+
+set_rate_limit(Cpid, Rl) ->
+    gen_server:call(Cpid, {set_rate_limit, Rl}).
+
+get_rate_limit(Cpid) ->
+    gen_server:call(Cpid, get_rate_limit).
 
 subscribe(CPid, TopicTable) ->
     gen_server:cast(CPid, {subscribe, TopicTable}).
@@ -119,6 +126,12 @@ handle_call(info, _From, State = #client_state{connection  = Connection,
 
 handle_call(kick, _From, State) ->
     {stop, {shutdown, kick}, ok, State};
+
+handle_call({set_rate_limit, Rl}, _From, State) ->
+    {reply, ok, State#client_state{rate_limit = Rl}};
+
+handle_call(get_rate_limit, _From, State = #client_state{rate_limit = Rl}) ->
+    {reply, Rl, State};
 
 handle_call(Req, _From, State) ->
     ?UNEXPECTED_REQ(Req, State).


### PR DESCRIPTION
This allows rate limits on a client to be queried
and changed dynamically (possibly by plugins), by
exposing additional apis.

`set_rate_limit/2` expects a Ratelimit tuple module of
the form `{module, record}` where module implements
`check(NumBytes, RlTuple) -> {TimeToPause, NewRlTuple}`

It is recommended that the rate limit module also
implement `new` to allow creating new RateLimit records.
See `esockd_ratelimit` for a reference implementation.