### PR TITLE
Feature: ACL extension

### DIFF
--- a/src/emqttd_topic.erl
+++ b/src/emqttd_topic.erl
@@ -22,7 +22,7 @@
 
 -type topic() :: binary().
 
--type word()   :: '' | '+' | '#' | binary().
+-type word()   :: '' | '+' | '#' | '?' | binary().
 
 -type words()  :: list(word()).
 
@@ -54,6 +54,12 @@ match(Name, Filter) when is_binary(Name) and is_binary(Filter) ->
 match([], []) ->
     true;
 match([H|T1], [H|T2]) ->
+    match(T1, T2);
+match(['+'|_], ['?'|_]) ->
+    false;
+match(['#'], ['?'|_]) ->
+    false;
+match([_H|T1], ['?'|T2]) ->
     match(T1, T2);
 match([<<$$, _/binary>>|_], ['+'|_]) ->
     false;
@@ -92,6 +98,8 @@ validate2([''|Words]) ->
     validate2(Words);
 validate2(['+'|Words]) ->
     validate2(Words);
+validate2(['?'|Words]) ->
+    validate2(Words);
 validate2([W|Words]) ->
     case validate3(W) of
         true -> validate2(Words);
@@ -100,7 +108,7 @@ validate2([W|Words]) ->
 
 validate3(<<>>) ->
     true;
-validate3(<<C/utf8, _Rest/binary>>) when C == $#; C == $+; C == 0 ->
+validate3(<<C/utf8, _Rest/binary>>) when C == $#; C == $+; C == $?; C == 0 ->
     false;
 validate3(<<_/utf8, Rest/binary>>) ->
     validate3(Rest).
@@ -124,6 +132,7 @@ join(Parent, W) ->
 
 bin('')  -> <<>>;
 bin('+') -> <<"+">>;
+bin('?') -> <<"?">>;
 bin('#') -> <<"#">>;
 bin(B) when is_binary(B) -> B.
 
@@ -134,6 +143,7 @@ words(Topic) when is_binary(Topic) ->
 
 word(<<>>)    -> '';
 word(<<"+">>) -> '+';
+word(<<"?">>) -> '?';
 word(<<"#">>) -> '#';
 word(Bin)     -> Bin.
 


### PR DESCRIPTION
New symbol `?` could be used in broker's ACLs to allow client subscribe to any single branch of subtree at the moment but not to the whole subtree section. For instance, we've got the following topic tree:

```
        a
      /   \
   b1       b2
  /  \     /   \
c1   c2   c1    c2
```

Let's compare effect of two ACL rules:
1) `{allow, {user, "test"}, subscribe, ["a/+/c1"]}`.
2) `{allow, {user, "test"}, subscribe, ["a/?/c1"]}`.

Using **rule 1** client will be able to subscribe `a/b1/c1` and `a/b2/c1` subtrees automatically, so all the b-level structure will be available to the client. There are some situations when you don't want to expose all the tree structure but at the same time allow clients to subscribe any specified subtopic on the c-level. Here we propose **rule 2**: client can subscribe e.g to `a/b1/c1` or to `a/b2/c1`, or to the both separately, but not to `a/+/c1` and if there is branch `a/b3/c1` information from it will not be available to the client until he explicitly subscribe to the branch.
