### PR TITLE
Hook 'client.unsubscribe' need to handle 'stop'

### DIFF
--- a/src/emqttd_protocol.erl
+++ b/src/emqttd_protocol.erl
@@ -130,9 +130,12 @@ handle({subscribe, RawTopicTable}, ProtoState = #proto_state{client_id = ClientI
 handle({unsubscribe, RawTopics}, ProtoState = #proto_state{client_id = ClientId,
                                                            username  = Username,
                                                            session   = Session}) ->
-    {ok, TopicTable} = emqttd:run_hooks('client.unsubscribe',
-                                        [ClientId, Username], parse_topics(RawTopics)),
-    emqttd_session:unsubscribe(Session, TopicTable),
+    case emqttd:run_hooks('client.unsubscribe', [ClientId, Username], parse_topics(RawTopics)) of
+        {ok, TopicTable} ->
+            emqttd_session:unsubscribe(Session, TopicTable);
+        {stop, _} ->
+            ok
+    end,
     {ok, ProtoState}.
 
 process(Packet = ?CONNECT_PACKET(Var), State0) ->
@@ -243,8 +246,13 @@ process(?UNSUBSCRIBE_PACKET(PacketId, []), State) ->
 
 process(?UNSUBSCRIBE_PACKET(PacketId, RawTopics), State = #proto_state{
         client_id = ClientId, username = Username, session = Session}) ->
-    {ok, TopicTable} = emqttd:run_hooks('client.unsubscribe', [ClientId, Username], parse_topics(RawTopics)),
-    emqttd_session:unsubscribe(Session, TopicTable),
+    case emqttd:run_hooks('client.unsubscribe', [ClientId, Username], parse_topics(RawTopics)) of
+        {ok, TopicTable} ->
+            emqttd_session:unsubscribe(Session, TopicTable);
+        {stop, _} ->
+            ok
+    end,
+    ,
     send(?UNSUBACK_PACKET(PacketId), State);
 
 process(?PACKET(?PINGREQ), State) ->

--- a/src/emqttd_protocol.erl
+++ b/src/emqttd_protocol.erl
@@ -252,7 +252,6 @@ process(?UNSUBSCRIBE_PACKET(PacketId, RawTopics), State = #proto_state{
         {stop, _} ->
             ok
     end,
-    ,
     send(?UNSUBACK_PACKET(PacketId), State);
 
 process(?PACKET(?PINGREQ), State) ->


### PR DESCRIPTION
Client unsubscribe hook does not handle 'stop' value. 
Insert a statement to prevent calling emqttd_session:unsubscribe() if hook returns stop.