### PR TITLE
Replace send with async_send

### DIFF
--- a/etc/emq.conf
+++ b/etc/emq.conf
@@ -546,3 +546,14 @@ sysmon.busy_port = false
 ## Busy Dist Port
 sysmon.busy_dist_port = true
 
+
+
+##-------------------------------------------------------------------
+## Websocket
+##-------------------------------------------------------------------
+
+websocket.async_send = true
+
+
+
+

--- a/priv/emq.schema
+++ b/priv/emq.schema
@@ -1311,3 +1311,13 @@ end}.
      {busy_dist_port, cuttlefish:conf_get("sysmon.busy_dist_port", Conf)}]
 end}.
 
+
+%%--------------------------------------------------------------------
+%% Mochiweb
+%%--------------------------------------------------------------------
+{mapping, "websocket.async_send", "mochiweb.ws_async_send", [
+  {default, true},
+  {datatype, {enum, [true, false]}}
+]}.
+
+

--- a/src/emqttd_client.erl
+++ b/src/emqttd_client.erl
@@ -137,7 +137,8 @@ send_fun(Conn, Peername) ->
         ?LOG(debug, "SEND ~p", [Data], #client_state{peername = Peername}),
         emqttd_metrics:inc('bytes/sent', iolist_size(Data)),
         try Conn:async_send(Data) of
-            true -> ok
+            true  -> ok;
+            false -> ok  % discard packet since peer's tcp window is full
         catch
             error:Error -> Self ! {shutdown, Error}
         end


### PR DESCRIPTION
If a websocket client's tcp windows size become zero, gen_tcp:send() will block.