### PR TITLE
fix #1529 retain msgs should not be sent to existing subscriptions

### DIFF
--- a/src/emqttd_protocol.erl
+++ b/src/emqttd_protocol.erl
@@ -569,11 +569,11 @@ sp(false) -> 0.
 
 clean_retain(false, Msg = #mqtt_message{retain = true, flags = Flags}) ->
     case Flags -- [new_sub_retain] of
-      Flags -> Msg#mqtt_message{retain = false};
+      Flags -> Msg#mqtt_message{retain = false}; % clean retain flag for existing subscription
       RetainFlags -> Msg#mqtt_message{flags = RetainFlags}
     end;
-clean_retain(_IsBridge, Msg) ->
-    Msg.
+clean_retain(_IsBridge, Msg = #mqtt_message{flags = Flags}) ->
+    Msg#mqtt_message{flags = Flags -- [new_sub_retain]}.
 
 %%--------------------------------------------------------------------
 %% Mount Point

--- a/src/emqttd_protocol.erl
+++ b/src/emqttd_protocol.erl
@@ -137,7 +137,7 @@ session(#proto_state{session = Session}) ->
 
 %% CONNECT – Client requests a connection to a Server
 
-%% A Client can only send the CONNECT Packet once over a Network Connection. 
+%% A Client can only send the CONNECT Packet once over a Network Connection.
 -spec(received(mqtt_packet(), proto_state()) -> {ok, proto_state()} | {error, term()}).
 received(Packet = ?PACKET(?CONNECT),
          State = #proto_state{connected = false, stats_data = Stats}) ->
@@ -449,14 +449,14 @@ start_keepalive(Sec, #proto_state{keepalive_backoff = Backoff}) when Sec > 0 ->
 
 validate_connect(Connect = #mqtt_packet_connect{}, ProtoState) ->
     case validate_protocol(Connect) of
-        true -> 
+        true ->
             case validate_clientid(Connect, ProtoState) of
-                true -> 
+                true ->
                     ?CONNACK_ACCEPT;
-                false -> 
+                false ->
                     ?CONNACK_INVALID_ID
             end;
-        false -> 
+        false ->
             ?CONNACK_PROTO_VER
     end.
 
@@ -498,7 +498,7 @@ validate_packet(?SUBSCRIBE_PACKET(_PacketId, TopicTable)) ->
 validate_packet(?UNSUBSCRIBE_PACKET(_PacketId, Topics)) ->
     validate_topics(filter, Topics);
 
-validate_packet(_Packet) -> 
+validate_packet(_Packet) ->
     ok.
 
 validate_topics(_Type, []) ->
@@ -567,10 +567,10 @@ sp(false) -> 0.
 %% The retained flag should be propagated for bridge.
 %%--------------------------------------------------------------------
 
-clean_retain(false, Msg = #mqtt_message{retain = true, headers = Headers}) ->
-    case lists:member(retained, Headers) of
-        true  -> Msg;
-        false -> Msg#mqtt_message{retain = false}
+clean_retain(false, Msg = #mqtt_message{retain = true, flags = Flags}) ->
+    case Flags -- [new_sub_retain] of
+      Flags -> Msg#mqtt_message{retain = false};
+      RetainFlags -> Msg#mqtt_message{flags = RetainFlags}
     end;
 clean_retain(_IsBridge, Msg) ->
     Msg.
@@ -593,4 +593,3 @@ unmount(MountPoint, Msg = #mqtt_message{topic = Topic}) ->
         {MountPoint, Topic0} -> Msg#mqtt_message{topic = Topic0};
         _ -> Msg
     end.
-


### PR DESCRIPTION
Mark the retained msg as 'new_sub_retain' for new subscriptions, and then we check that when cleaning the retain flag for existing subscriptions.
Another commit is in the emq_retainer plugin project. https://github.com/emqtt/emq-retainer/pull/49
