### PR TITLE
change log level: warning -> info on stop publish

### DIFF
--- a/src/emqttd_server.erl
+++ b/src/emqttd_server.erl
@@ -92,7 +92,7 @@ publish(Msg = #mqtt_message{from = From}) ->
         {ok, Msg1 = #mqtt_message{topic = Topic}} ->
             emqttd_pubsub:publish(Topic, Msg1);
         {stop, Msg1} ->
-            lager:warning("Stop publishing: ~s", [emqttd_message:format(Msg1)]),
+            lager:info("Stop publishing: ~s", [emqttd_message:format(Msg1)]),
             ignore
     end.
 


### PR DESCRIPTION
Message publishes may be prevented by hooks by returning `{stop, Msg}`
or variants. However, this causes a log message at warning level.

Since a hook can potentially prevent multiple messages rapidly, these
warning messages pollute the logs. Similar level of detail is present
currently at info level, so demoting this message to info.